### PR TITLE
fix(CLI): delete the existing output file when CLI::Curl() is called

### DIFF
--- a/Aoba/src/CommandLine/CommandLine.cpp
+++ b/Aoba/src/CommandLine/CommandLine.cpp
@@ -42,6 +42,10 @@ namespace s3d::CLI {
 			FileSystem::CreateDirectories(FileSystem::ParentPath(output));
 		}
 
+		if (FileSystem::Exists(output)) {
+			FileSystem::Remove(output);
+		}
+
 #if SIV3D_PLATFORM(WINDOWS)
 		result &= Execute(U"Invoke-WebRequest \\\"{}\\\" -OutFile \\\"{}\\\" -UseBasicParsing"_fmt(url, output));
 #else


### PR DESCRIPTION
close #142 