### PR TITLE
依存レイヤの管理方法を改善

### DIFF
--- a/Aoba/include/Aoba/UIComponent.hpp
+++ b/Aoba/include/Aoba/UIComponent.hpp
@@ -70,9 +70,10 @@ namespace s3d::aoba {
         bool m_initializedColors = false;
 
         Layer m_layer;
-        Array<Layer*> m_dependentLayers;
-        Rect m_drawableRegion    = Rect();
-        bool m_needToUpdateLayer = true;
+        Array<std::shared_ptr<UIComponent>> m_dependentComponents;
+        Rect m_drawableRegion              = Rect();
+        bool m_constraintsUpdatedThisFrame = false;
+        bool m_needToUpdateLayer           = true;
 
         // Mouse event
         MouseCondition m_mouseCondition;
@@ -222,5 +223,7 @@ namespace s3d::aoba {
         static void UpdateFocusEvent();
 
         virtual bool updateLayerIfNeeded(const Rect& scissor);
+
+        void updateConstraints();
     };
 }

--- a/Aoba/src/Component/UIComponent.cpp
+++ b/Aoba/src/Component/UIComponent.cpp
@@ -131,6 +131,7 @@ namespace s3d::aoba {
 
     void UIComponent::removeAllConstraints() {
         m_layer.removeAllConstraints();
+        m_dependentComponents.release();
     }
 
     void UIComponent::focus() {

--- a/Aoba/src/Component/UIComponent.cpp
+++ b/Aoba/src/Component/UIComponent.cpp
@@ -45,6 +45,8 @@ namespace s3d::aoba {
     }
 
     void UIComponent::update() {
+        m_constraintsUpdatedThisFrame = false;
+
         if (isFocused()) {
             for (auto& shortcut : m_keyShortcuts) {
                 if (shortcut->keyDown()) {
@@ -62,10 +64,7 @@ namespace s3d::aoba {
 
         m_drawableRegion = scissor;
 
-        for (auto layer : m_dependentLayers) {
-            layer->updateConstraints();
-        }
-        m_layer.updateConstraints();
+        updateConstraints();
     }
 
     bool UIComponent::updateLayerIfNeeded(const Rect& scissor) {
@@ -78,12 +77,29 @@ namespace s3d::aoba {
         return false;
     }
 
+    void UIComponent::updateConstraints() {
+        if (!m_constraintsUpdatedThisFrame) {
+            // Update layer of dependent components before updating self
+            for (auto& component : m_dependentComponents) {
+                component->updateConstraints();
+            }
+
+            m_layer.updateConstraints();
+        }
+        m_constraintsUpdatedThisFrame = true;
+    }
+
     void UIComponent::setConstraint(LayerDirection direction,
                                     UIComponent& component,
                                     LayerDirection toDirection,
                                     double constant,
                                     double multiplier) {
-        m_dependentLayers.emplace_back(&component.m_layer);
+        if (!m_dependentComponents.includes_if([&component](const std::shared_ptr<UIComponent>& dependent) {
+                return dependent->id() == component.id();
+            })) {
+            m_dependentComponents.emplace_back(ComponentStorage::Get(component.id()));
+        }
+
         m_layer.setConstraint(direction, component.m_layer, toDirection, constant, multiplier);
         m_needToUpdateLayer = true;
     }


### PR DESCRIPTION
close #163 

- 依存レイヤではなく依存コンポーネントを保持
- 依存コンポーネントは重複しないように格納される
- `UIComponent::removeAllConstraints()`呼び出し時に依存コンポーネントは解放される
- 依存コンポーネントのレイヤを更新後、自身のレイヤを更新
- レイヤの更新は１フレームにつき１回のみ行われる。